### PR TITLE
websocketのリクエストヘッダがないとエラーログが流れるのを修正

### DIFF
--- a/src/main/java/jp/co/gsol/oss/notifications/ResinWebSocketServlet.java
+++ b/src/main/java/jp/co/gsol/oss/notifications/ResinWebSocketServlet.java
@@ -47,7 +47,15 @@ public class ResinWebSocketServlet extends GenericServlet {
             res.setHeader("Sec-WebSocket-Protocol", protocol);
             final WebSocketServletRequest wsRequest = (WebSocketServletRequest)
                     ((TransitionLogHttpServletRequestWrapper) request).getRequest();
-            wsRequest.startWebSocket(listener);
+            
+            try {
+                wsRequest.startWebSocket(listener);
+            } catch (IllegalStateException e) {
+                Logger.getLogger().info("websocket request error: {}", e.getMessage());
+                res.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                return;
+            }
+            
             if (wst.processClass().isPresent()) {
             // start push event loop
                 try {

--- a/src/main/java/jp/co/gsol/oss/notifications/ResinWebSocketServlet.java
+++ b/src/main/java/jp/co/gsol/oss/notifications/ResinWebSocketServlet.java
@@ -52,7 +52,6 @@ public class ResinWebSocketServlet extends GenericServlet {
                 wsRequest.startWebSocket(listener);
             } catch (IllegalStateException e) {
                 Logger.getLogger().info("websocket request error: {}", e.getMessage());
-                res.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
                 return;
             }
             


### PR DESCRIPTION
## What

websocketのリクエストヘッダがないとエラーログが流れるのを修正する。

